### PR TITLE
Make last li in lo fire moveItem events too.

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -907,7 +907,7 @@ micro.OL = class extends HTMLOListElement {
 
                 // Prevent scrolling and text selection
                 event.preventDefault();
-                this._from = this._li.nextElementSibling;
+                this._from = this._li.nextElementSibling ?? this.li;
                 this._to = null;
                 this._over = this._li;
                 this._li.classList.add("micro-ol-li-moving");


### PR DESCRIPTION
Hello,

this little fix is needed to move the last `<li>` in a `<lo>` on click in listling, because otherwise no moveItem events are triggered for the last li.

This is a requirement for https://github.com/noyainrain/listling/pull/116

BR
Michael